### PR TITLE
feat: fix bugs and add emo-music function

### DIFF
--- a/app/src/main/java/com/nicer/attiary/view/setting/lock/SettingActivity.kt
+++ b/app/src/main/java/com/nicer/attiary/view/setting/lock/SettingActivity.kt
@@ -5,16 +5,15 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
 import android.widget.ArrayAdapter
-import android.widget.Switch
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import com.nicer.attiary.R
-import com.nicer.attiary.databinding.ActivitySettingBinding
 import com.nicer.attiary.data.password.AppLock
 import com.nicer.attiary.data.password.AppLock.AppLockStatus.lock
 import com.nicer.attiary.data.user.UserHelper
+import com.nicer.attiary.databinding.ActivitySettingBinding
 import com.nicer.attiary.view.common.AppPassWordActivity
 import com.nicer.attiary.view.common.GlobalApplication
 import com.nicer.attiary.view.signature.MusicService
@@ -25,17 +24,17 @@ import kotlinx.coroutines.launch
 
 class SettingActivity : AppCompatActivity() {
 
-	val binding by lazy { ActivitySettingBinding.inflate(layoutInflater) }
-	var helper: UserHelper? = null
-	lateinit var intent_music: Intent
+    val binding by lazy { ActivitySettingBinding.inflate(layoutInflater) }
+    var helper: UserHelper? = null
+    lateinit var sigmu_intent: Intent
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 		setContentView(binding.root)
 
-		init()
-		helper = UserHelper.getInstance(this)
-		intent_music = Intent(this, MusicService::class.java)
+        init()
+        helper = UserHelper.getInstance(this)
+        sigmu_intent = Intent(this, MusicService::class.java)
 
 		val activityResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()){
 			val returnCode = it.data?.getIntExtra("returnCode", 0)
@@ -100,16 +99,15 @@ class SettingActivity : AppCompatActivity() {
 			binding.changeBdayBtn.isVisible=true
 		}
 
-		binding.sigMusicSwitch.setOnCheckedChangeListener { _, isChecked ->
-			if (isChecked){
-				GlobalApplication.musicPrefs.setString("sigMusic", "sON")
-				startService(intent_music)
-			}
-			else{
-				GlobalApplication.musicPrefs.setString("sigMusic", "sOF")
-				stopService(intent_music)
-			}
-		}
+        binding.sigMusicSwitch.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                GlobalApplication.musicPrefs.setString("sigMusic", "sON")
+                startService(sigmu_intent)
+            } else {
+                GlobalApplication.musicPrefs.setString("sigMusic", "sOF")
+                stopService(sigmu_intent)
+            }
+        }
 
 		val sigCheck = GlobalApplication.musicPrefs.getString("sigMusic","")
 		binding.sigMusicSwitch.isChecked = sigCheck == "sON"

--- a/app/src/main/java/com/nicer/attiary/view/signature/HomeActivity.kt
+++ b/app/src/main/java/com/nicer/attiary/view/signature/HomeActivity.kt
@@ -8,6 +8,7 @@ import android.text.style.ForegroundColorSpan
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import com.google.gson.Gson
+import com.nicer.attiary.R
 import com.nicer.attiary.data.diary.DiaryList
 import com.nicer.attiary.data.password.AppLock
 import com.nicer.attiary.data.report.ReportDatabase
@@ -15,294 +16,296 @@ import com.nicer.attiary.databinding.ActivityHomeBinding
 import com.nicer.attiary.view.common.AppPassWordActivity
 import com.nicer.attiary.view.setting.lock.SettingActivity
 import com.nicer.attiary.view.write.WriteActivity
-import com.prolificinteractive.materialcalendarview.*
+import com.prolificinteractive.materialcalendarview.CalendarDay
+import com.prolificinteractive.materialcalendarview.CalendarMode
+import com.prolificinteractive.materialcalendarview.DayViewDecorator
+import com.prolificinteractive.materialcalendarview.DayViewFacade
 import java.util.*
-import com.nicer.attiary.R
 
 
 class HomeActivity : AppCompatActivity() {
-	private val binding by lazy { ActivityHomeBinding.inflate(layoutInflater) }
+    private val binding by lazy { ActivityHomeBinding.inflate(layoutInflater) }
 
-	var database: ReportDatabase? = null
-	private var startTimeCalendar = Calendar.getInstance()
-	private var endTimeCalendar = Calendar.getInstance()
-	private val currentYear = startTimeCalendar.get(Calendar.YEAR)
-	private val currentMonth = startTimeCalendar.get(Calendar.MONTH)
-	private val currentDate = startTimeCalendar.get(Calendar.DATE)
-	private val enCalendarDay = CalendarDay(
-		endTimeCalendar.get(Calendar.YEAR),
-		endTimeCalendar.get(Calendar.MONTH),
-		endTimeCalendar.get(Calendar.DATE)
-	)
-	private val minMaxDecorator = MinMaxDecorator(enCalendarDay)
-	lateinit var intent_music: Intent
+    var database: ReportDatabase? = null
+    private var startTimeCalendar = Calendar.getInstance()
+    private var endTimeCalendar = Calendar.getInstance()
+    private val currentYear = startTimeCalendar.get(Calendar.YEAR)
+    private val currentMonth = startTimeCalendar.get(Calendar.MONTH)
+    private val currentDate = startTimeCalendar.get(Calendar.DATE)
+    private val enCalendarDay = CalendarDay(
+        endTimeCalendar.get(Calendar.YEAR),
+        endTimeCalendar.get(Calendar.MONTH),
+        endTimeCalendar.get(Calendar.DATE)
+    )
+    private val minMaxDecorator = MinMaxDecorator(enCalendarDay)
+    lateinit var sigmu_intent: Intent
 
-	override fun onCreate(savedInstanceState: Bundle?) {
-		super.onCreate(savedInstanceState)
-		setContentView(binding.root)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
 
-		intent_music = Intent(this, MusicService::class.java)
+        sigmu_intent = Intent(this, MusicService::class.java)
 
-		binding.calendarView.addDecorators(minMaxDecorator)
-		binding.toolbar.bringToFront()
-		database = ReportDatabase.getInstance(this, Gson())
-		binding.calendarView.state().edit()
-			.setFirstDayOfWeek(Calendar.MONDAY)
-			.setMaximumDate(
-				CalendarDay.from(
-					currentYear,
-					currentMonth,
-					endTimeCalendar.getActualMaximum(Calendar.DAY_OF_MONTH)
-				)
-			)
-			.setCalendarDisplayMode(CalendarMode.MONTHS)
-			.commit()
-		binding.calendarView.isDynamicHeightEnabled = true
-		binding.barFindText.text = monthToString(currentMonth)
-		binding.calendarView.setOnMonthChangedListener { _, date ->
-			val year = date.year
-			val month = date.month
-			if (year == currentYear)
-				binding.barFindText.text = monthToString(month)
-			else
-				("$year " + monthToString(month)).also { binding.barFindText.text = it }
-		}
+        binding.calendarView.addDecorators(minMaxDecorator)
+        binding.toolbar.bringToFront()
+        database = ReportDatabase.getInstance(this, Gson())
+        binding.calendarView.state().edit()
+            .setFirstDayOfWeek(Calendar.MONDAY)
+            .setMaximumDate(
+                CalendarDay.from(
+                    currentYear,
+                    currentMonth,
+                    endTimeCalendar.getActualMaximum(Calendar.DAY_OF_MONTH)
+                )
+            )
+            .setCalendarDisplayMode(CalendarMode.MONTHS)
+            .commit()
+        binding.calendarView.isDynamicHeightEnabled = true
+        binding.barFindText.text = monthToString(currentMonth)
+        binding.calendarView.setOnMonthChangedListener { _, date ->
+            val year = date.year
+            val month = date.month
+            if (year == currentYear)
+                binding.barFindText.text = monthToString(month)
+            else
+                ("$year " + monthToString(month)).also { binding.barFindText.text = it }
+        }
 
-		binding.newButton.setOnClickListener {
-			val year = currentYear
-			val month = currentMonth
-			val dayOfMonth = currentDate
-			val rDate = CalendarDay(year, month, dayOfMonth)
+        binding.newButton.setOnClickListener {
+            val year = currentYear
+            val month = currentMonth
+            val dayOfMonth = currentDate
+            val rDate = CalendarDay(year, month, dayOfMonth)
 
-			nextView(year, month, dayOfMonth, rDate)
-		}
+            nextView(year, month, dayOfMonth, rDate)
+        }
 
-		binding.calendarView.setOnDateChangedListener { widget, date, selected ->
-			val year = widget.selectedDate.year
-			val month = widget.selectedDate.month
-			val dayOfMonth = widget.selectedDate.day
-			val rDate = CalendarDay(year, month, dayOfMonth)
-			nextView(year, month, dayOfMonth, rDate)
-		}
+        binding.calendarView.setOnDateChangedListener { widget, date, selected ->
+            val year = widget.selectedDate.year
+            val month = widget.selectedDate.month
+            val dayOfMonth = widget.selectedDate.day
+            val rDate = CalendarDay(year, month, dayOfMonth)
+            nextView(year, month, dayOfMonth, rDate)
+        }
 
 
-		binding.settingBtn.setOnClickListener{
-			startActivity(
-				Intent(
-					this,
-					SettingActivity::class.java
-				).apply { addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION) })
-		}
+        binding.settingBtn.setOnClickListener {
+            startActivity(
+                Intent(
+                    this,
+                    SettingActivity::class.java
+                ).apply { addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION) })
+        }
 
-		binding.statsView.setOnClickListener {
-			startActivity(
-				Intent(
-					this,
-					MonthlyReportActivity::class.java
-				).apply { addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION) })
-		}
+        binding.statsView.setOnClickListener {
+            startActivity(
+                Intent(
+                    this,
+                    MonthlyReportActivity::class.java
+                ).apply { addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION) })
+        }
 
-	}
+    }
 
-	private fun monthToString(month: Int): String {
-		lateinit var monthString: String
-		when (month) {
-			0 -> monthString = "January"
-			1 -> monthString = "February"
-			2 -> monthString = "March"
-			3 -> monthString = "April"
-			4 -> monthString = "May"
-			5 -> monthString = "June"
-			6 -> monthString = "July"
-			7 -> monthString = "August"
-			8 -> monthString = "September"
-			9 -> monthString = "October"
-			10 -> monthString = "November"
-			11 -> monthString = "December"
-		}
-		return monthString
-	}
+    private fun monthToString(month: Int): String {
+        lateinit var monthString: String
+        when (month) {
+            0 -> monthString = "January"
+            1 -> monthString = "February"
+            2 -> monthString = "March"
+            3 -> monthString = "April"
+            4 -> monthString = "May"
+            5 -> monthString = "June"
+            6 -> monthString = "July"
+            7 -> monthString = "August"
+            8 -> monthString = "September"
+            9 -> monthString = "October"
+            10 -> monthString = "November"
+            11 -> monthString = "December"
+        }
+        return monthString
+    }
 
-	fun nextView(year: Int, month: Int, dayOfMonth: Int, rDate: CalendarDay) {
-		if (DiaryList(this).isExist(rDate)) {
-			val intent: Intent = Intent(this, DiaryActivity::class.java)
-			intent.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION)
-			intent.putExtra("year", year)
-			intent.putExtra("month", month)
-			intent.putExtra("dayOfMonth", dayOfMonth)
-			startActivity(intent)
-		} else {
-			val intent: Intent = Intent(this, WriteActivity::class.java)
-			intent.putExtra("year", year);
-			intent.putExtra("month", month);
-			intent.putExtra("dayOfMonth", dayOfMonth);
-			intent.putExtra("diary", "")
-			startActivity(intent)
-		}
-	}
+    fun nextView(year: Int, month: Int, dayOfMonth: Int, rDate: CalendarDay) {
+        if (DiaryList(this).isExist(rDate)) {
+            val intent: Intent = Intent(this, DiaryActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION)
+            intent.putExtra("year", year)
+            intent.putExtra("month", month)
+            intent.putExtra("dayOfMonth", dayOfMonth)
+            startActivity(intent)
+        } else {
+            val intent: Intent = Intent(this, WriteActivity::class.java)
+            intent.putExtra("year", year);
+            intent.putExtra("month", month);
+            intent.putExtra("dayOfMonth", dayOfMonth);
+            intent.putExtra("diary", "")
+            startActivity(intent)
+        }
+    }
 
-	override fun onResume() {
-		binding.calendarView.addDecorator(AngerDecorator(this))
-		binding.calendarView.addDecorator(AnxietyDecorator(this))
-		binding.calendarView.addDecorator(HopeDecorator(this))
-		binding.calendarView.addDecorator(JoyDecorator(this))
-		binding.calendarView.addDecorator(NeutralityDecorator(this))
-		binding.calendarView.addDecorator(RegretDecorator(this))
-		binding.calendarView.addDecorator(SadnessDecorator(this))
-		binding.calendarView.addDecorator(TirednessDecorator(this))
-		binding.calendarView.addDecorator(ErrorDecorator(this))
+    override fun onResume() {
+        binding.calendarView.addDecorator(AngerDecorator(this))
+        binding.calendarView.addDecorator(AnxietyDecorator(this))
+        binding.calendarView.addDecorator(HopeDecorator(this))
+        binding.calendarView.addDecorator(JoyDecorator(this))
+        binding.calendarView.addDecorator(NeutralityDecorator(this))
+        binding.calendarView.addDecorator(RegretDecorator(this))
+        binding.calendarView.addDecorator(SadnessDecorator(this))
+        binding.calendarView.addDecorator(TirednessDecorator(this))
+        binding.calendarView.addDecorator(ErrorDecorator(this))
 
-		super.onResume()
-		if (AppLock.AppLockStatus.lock && AppLock(this).isPassLockSet()) {
-			val intent = Intent(this, AppPassWordActivity::class.java).apply {
-				addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION)
-				putExtra("type", AppLock.AppLockStatus.UNLOCK_PASSWORD)
-			}
-			startActivity(intent)
-		}
-		window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-		startService(intent_music)
-	}
+        super.onResume()
+        if (AppLock.AppLockStatus.lock && AppLock(this).isPassLockSet()) {
+            val intent = Intent(this, AppPassWordActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION)
+                putExtra("type", AppLock.AppLockStatus.UNLOCK_PASSWORD)
+            }
+            startActivity(intent)
+        }
+        window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        startService(sigmu_intent)
+    }
 
-	override fun onUserLeaveHint() {
-		super.onUserLeaveHint()
-		stopService(intent_music)
-	}
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        stopService(sigmu_intent)
+    }
 
-	override fun onPause() {
-		super.onPause()
-		window.setFlags(
-			WindowManager.LayoutParams.FLAG_SECURE,
-			WindowManager.LayoutParams.FLAG_SECURE
-		)
-	}
+    override fun onPause() {
+        super.onPause()
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
+    }
 }
 
 class MinMaxDecorator(max: CalendarDay) : DayViewDecorator {
-	val maxDay = max
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return (day?.month == maxDay.month && day.day > maxDay.day)
-	}
+    val maxDay = max
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return (day?.month == maxDay.month && day.day > maxDay.day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		view?.addSpan(object : ForegroundColorSpan(Color.parseColor("#E5E4E4")) {})
-		view?.setDaysDisabled(true)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        view?.addSpan(object : ForegroundColorSpan(Color.parseColor("#E5E4E4")) {})
+        view?.setDaysDisabled(true)
+    }
 }
 
-class AngerDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_anger)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isAnger(day)
-	}
+class AngerDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_anger)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isAnger(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if(drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }
 
-class AnxietyDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_anxiety)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isAnxiety(day)
-	}
+class AnxietyDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_anxiety)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isAnxiety(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if(drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }
 
-class HopeDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_hope)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isHope(day)
-	}
+class HopeDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_hope)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isHope(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if(drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }
 
-class JoyDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_joy)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isJoy(day)
-	}
+class JoyDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_joy)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isJoy(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if(drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }
 
-class NeutralityDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_neutrality)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isNeutrality(day)
-	}
+class NeutralityDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_neutrality)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isNeutrality(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if(drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }
 
-class RegretDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_regret)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isRegret(day)
-	}
+class RegretDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_regret)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isRegret(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if(drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }
 
-class SadnessDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_sadness)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isSadness(day)
-	}
+class SadnessDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_sadness)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isSadness(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if (drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }
 
-class TirednessDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_tiredness)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isTiredness(day)
-	}
+class TirednessDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_tiredness)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isTiredness(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if (drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }
 
-class ErrorDecorator(context: Context): DayViewDecorator {
-	val drawable = context.getDrawable(R.drawable.calendar_circle_error)
-	val diary = DiaryList(context)
-	override fun shouldDecorate(day: CalendarDay?): Boolean {
-		return diary.isError(day)
-	}
+class ErrorDecorator(context: Context) : DayViewDecorator {
+    val drawable = context.getDrawable(R.drawable.calendar_circle_error)
+    val diary = DiaryList(context)
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return diary.isError(day)
+    }
 
-	override fun decorate(view: DayViewFacade?) {
-		if (drawable != null)
-			view?.setSelectionDrawable(drawable)
-	}
+    override fun decorate(view: DayViewFacade?) {
+        if (drawable != null)
+            view?.setSelectionDrawable(drawable)
+    }
 }

--- a/app/src/main/java/com/nicer/attiary/view/signature/MusicService.kt
+++ b/app/src/main/java/com/nicer/attiary/view/signature/MusicService.kt
@@ -4,7 +4,6 @@ import android.app.Service
 import android.content.Intent
 import android.media.MediaPlayer
 import android.os.IBinder
-import android.util.Log
 import androidx.annotation.Nullable
 import com.nicer.attiary.R
 import com.nicer.attiary.view.common.GlobalApplication

--- a/app/src/main/java/com/nicer/attiary/view/write/WriteActivity.kt
+++ b/app/src/main/java/com/nicer/attiary/view/write/WriteActivity.kt
@@ -357,6 +357,7 @@ class WriteActivity : AppCompatActivity() {
         }
 
         binding.btnMusic.setOnLongClickListener {
+            binding.contextEditText.clearFocus()
             setFragment(MusicPopupFragment())
             true
         }

--- a/app/src/main/java/com/nicer/attiary/view/write/WriteActivity.kt
+++ b/app/src/main/java/com/nicer/attiary/view/write/WriteActivity.kt
@@ -76,9 +76,8 @@ class WriteActivity : AppCompatActivity() {
         }
 
         binding.saveBtn.setOnClickListener {
-            startService(sigmu_intent)
-
             hideKeyboard()
+            
             if (binding.contextEditText.text.isBlank()) {
                 val builder = AlertDialog.Builder(this)
                 builder.setMessage("내용을 입력하세요.")
@@ -89,136 +88,11 @@ class WriteActivity : AppCompatActivity() {
                     DiaryList(this).removeDiary(CalendarDay(year, month, dayOfMonth))
                 }
 
-                //로딩화면
-
-                val content = binding.contextEditText.text.toString()
-                var emotions = hashMapOf<String, Int>()
-                var dDepression = 0
-                RetrofitObject.getApiService().getReport(content)
-                    .enqueue(object : Callback<Classification> {
-                        override fun onResponse(
-                            call: Call<Classification>,
-                            response: Response<Classification>
-                        ) {
-                            Log.d("YMC", "ㅎ")
-                            if (response.isSuccessful) {
-                                var result: Classification? = response.body()
-                                Log.d("YMC", "onResponse 성공: ")
-                                emotions.put("anger", ((result?.anger)?.times(100))?.toInt()!!)
-                                emotions.put("anxiety", ((result.anxiety)?.times(100))?.toInt()!!)
-                                emotions.put("hope", ((result.hope)?.times(100))?.toInt()!!)
-                                emotions.put("joy", ((result.joy)?.times(100))?.toInt()!!)
-                                emotions.put("regret", ((result.regret)?.times(100))?.toInt()!!)
-                                emotions.put("sadness", ((result.sadness)?.times(100))?.toInt()!!)
-                                emotions.put(
-                                    "tiredness",
-                                    ((result.tiredness)?.times(100))?.toInt()!!
-                                )
-                                dDepression = (result.depression)?.times(100)?.toInt()!!
-                                Log.d("result", result.toString())
-                            } else {
-                                // 통신 실패
-                                Log.d("YMC", "onResponse 실패")
-                            }
-                        }
-
-                        override fun onFailure(call: Call<Classification>, t: Throwable) {
-                            // 통신 실패 (인터넷 끊킴, 예외 발생 등 시스템적인 이유)
-                            Log.d("YMC", "onFailure 에러: " + t.message.toString())
-                        }
-                    })
-
-                Handler(Looper.getMainLooper()).postDelayed({
-                    try {
-                        Log.d("emotions", emotions.toString())
-                        val emotions2 = emotions.toList().sortedByDescending { (_, value) -> value }
-                            .toMap() as HashMap<String, Int>
-                        val e1 = emotions2.keys.elementAt(0)
-                        val p1 = emotions2.getValue(e1)
-                        var happiness = emotions.get("joy")?.plus(emotions.get("hope")!!)
-                        var depression = emotions.get("anger")?.plus(emotions.get("sadness")!!)
-                            ?.plus(emotions.get("anxiety")!!)?.plus(emotions.get("tiredness")!!)
-                            ?.plus(emotions.get("regret")!!)?.plus(dDepression)
-                        var representative = setRepresentative(e1, p1)
-                        CoroutineScope(Dispatchers.IO).launch {
-                            database?.ReportDao()?.insert(
-                                Report(
-                                    rDate,
-                                    content,
-                                    representative,
-                                    emotions,
-                                    happiness!!,
-                                    depression!!,
-                                    ""
-                                )
-                            )
-                        }
-                        if (p1 == 0)
-                            DiaryList(this).addDiary(
-                                CalendarDay(year, month, dayOfMonth),
-                                "neurality"
-                            )
-                        else
-                            DiaryList(this).addDiary(CalendarDay(year, month, dayOfMonth), e1)
-                    } catch (e: ClassCastException) {
-                        Log.d("[error]", "ClassCastException")
-                        //로딩화면 닫고
-                        //서버가 불안정하니 다음에 다시 시도하라는 창: 일기내용만 저장해둘게요! 분석을 다시 시도하려면 수정 버튼을 누르고 다시 저장해보세요!
-                        emotions.put("anger", 0)
-                        emotions.put("anxiety", 0)
-                        emotions.put("hope", 0)
-                        emotions.put("joy", 0)
-                        emotions.put("regret", 0)
-                        emotions.put("sadness", 0)
-                        emotions.put("tiredness", 0)
-
-                        var happiness = emotions.get("joy")?.plus(emotions.get("hope")!!)
-                        var depression = emotions.get("anger")?.plus(emotions.get("sadness")!!)
-                            ?.plus(emotions.get("anxiety")!!)?.plus(emotions.get("tiredness")!!)
-                            ?.plus(emotions.get("regret")!!)?.plus(dDepression)
-                        var representative = "neutrality"
-                        CoroutineScope(Dispatchers.IO).launch {
-                            database?.ReportDao()?.insert(
-                                Report(
-                                    rDate,
-                                    content,
-                                    representative,
-                                    emotions,
-                                    happiness!!,
-                                    depression!!,
-                                    ""
-                                )
-                            )
-                        }
-                        DiaryList(this).addDiary(CalendarDay(year, month, dayOfMonth), "neutrality")
-                    } finally {
-                        //로딩화면 닫힘
-                        val intent = Intent(this, DiaryActivity::class.java)
-                        intent.putExtra("year", year)
-                        intent.putExtra("month", month)
-                        intent.putExtra("dayOfMonth", dayOfMonth)
-                        startActivity(intent)
-                        finish()
-                    }
-                }, 10000)
-
-
-            }
-        }
-
-        binding.saveBtn.setOnClickListener {
-            startService(sigmu_intent)
-
-            hideKeyboard()
-            if (binding.contextEditText.text.isBlank()) {
-                val builder = AlertDialog.Builder(this)
-                builder.setMessage("내용을 입력하세요.")
-                builder.setPositiveButton("확인", null)
-                builder.show()
-            } else {
-                if (str != "null") {
-                    DiaryList(this).removeDiary(CalendarDay(year, month, dayOfMonth))
+                if (emoMP?.isPlaying == true) {
+                    emoMP?.stop()
+                    emoMP?.release()
                 }
+                startService(sigmu_intent)
 
                 binding.wholeView.bringToFront()
                 setLoadingFrag()

--- a/app/src/main/java/com/nicer/attiary/view/write/WriteActivity.kt
+++ b/app/src/main/java/com/nicer/attiary/view/write/WriteActivity.kt
@@ -205,117 +205,156 @@ class WriteActivity : AppCompatActivity() {
 
             }
         }
-        
-		binding.saveBtn.setOnClickListener {
-			startService(intent_music)
-			hideKeyboard()
-			if (binding.contextEditText.text.isBlank()) {
-				val builder = AlertDialog.Builder(this)
-				builder.setMessage("내용을 입력하세요.")
-				builder.setPositiveButton("확인", null)
-				builder.show()
-			} else {
-				if (str != "null") {
-					DiaryList(this).removeDiary(CalendarDay(year, month, dayOfMonth))
-				}
 
-				binding.wholeView.bringToFront()
-				setLoadingFrag()
+        binding.saveBtn.setOnClickListener {
+            startService(sigmu_intent)
 
-				val content = binding.contextEditText.text.toString()
-				var emotions = hashMapOf<String, Int>()
-				var dDepression = 0
+            hideKeyboard()
+            if (binding.contextEditText.text.isBlank()) {
+                val builder = AlertDialog.Builder(this)
+                builder.setMessage("내용을 입력하세요.")
+                builder.setPositiveButton("확인", null)
+                builder.show()
+            } else {
+                if (str != "null") {
+                    DiaryList(this).removeDiary(CalendarDay(year, month, dayOfMonth))
+                }
 
-				CoroutineScope(Dispatchers.IO).async {
-					RetrofitObject.getApiService().getReport(content)?.enqueue(object : Callback<Classification> {
-						override fun onResponse(call: Call<Classification>, response: Response<Classification>) {
-							Log.d("YMC", "ㅎ")
-							if (response.isSuccessful) {
-								var result: Classification? = response.body()
-								Log.d("YMC", "onResponse 성공: ")
-								emotions.put("anger", ((result?.anger)?.times(100))?.toInt()!!)
-								emotions.put("anxiety", ((result?.anxiety)?.times(100))?.toInt()!!)
-								emotions.put("hope", ((result?.hope)?.times(100))?.toInt()!!)
-								emotions.put("joy", ((result?.joy)?.times(100))?.toInt()!!)
-								emotions.put("regret", ((result?.regret)?.times(100))?.toInt()!!)
-								emotions.put("sadness", ((result?.sadness)?.times(100))?.toInt()!!)
-								emotions.put("tiredness", ((result?.tiredness)?.times(100))?.toInt()!!)
-								dDepression = (result?.depression)?.times(100)?.toInt()!!
-								Log.d("result", result.toString())
-							} else {
-								// 통신 실패
-								Log.d("YMC", "onResponse 실패")
-							}
-						}
+                binding.wholeView.bringToFront()
+                setLoadingFrag()
 
-						override fun onFailure(call: Call<Classification>, t: Throwable) {
-							// 통신 실패 (인터넷 끊킴, 예외 발생 등 시스템적인 이유)
-							Log.d("YMC", "onFailure 에러: " + t.message.toString());
-						}
-					})
-				}
-        
+                val content = binding.contextEditText.text.toString()
+                var emotions = hashMapOf<String, Int>()
+                var dDepression = 0
 
-				Handler(Looper.getMainLooper()).postDelayed({
-					try{
-						Log.d("emotions", emotions.toString())
-						val emotions2 = emotions.toList().sortedByDescending{ (_, value) -> value}.toMap() as HashMap<String, Int>
-						val e1 = emotions2.keys.elementAt(0)
-						val p1 = emotions2.getValue(e1)
-						var happiness = emotions.get("joy")?.plus(emotions.get("hope")!!)
-						var depression = emotions.get("anger")?.plus(emotions.get("sadness")!!)?.plus(emotions.get("anxiety")!!)?.plus(emotions.get("tiredness")!!)?.plus(emotions.get("regret")!!)?.plus(dDepression)
-						var representative = setRepresentative(e1, p1)
-						CoroutineScope(Dispatchers.IO).launch {
-							database?.ReportDao()?.insert(
-								Report(rDate, content, representative, emotions, happiness!!, depression!!, "")
-							)
-						}
+                CoroutineScope(Dispatchers.IO).async {
+                    RetrofitObject.getApiService().getReport(content)
+                        ?.enqueue(object : Callback<Classification> {
+                            override fun onResponse(
+                                call: Call<Classification>,
+                                response: Response<Classification>
+                            ) {
+                                Log.d("YMC", "ㅎ")
+                                if (response.isSuccessful) {
+                                    var result: Classification? = response.body()
+                                    Log.d("YMC", "onResponse 성공: ")
+                                    emotions.put("anger", ((result?.anger)?.times(100))?.toInt()!!)
+                                    emotions.put(
+                                        "anxiety",
+                                        ((result?.anxiety)?.times(100))?.toInt()!!
+                                    )
+                                    emotions.put("hope", ((result?.hope)?.times(100))?.toInt()!!)
+                                    emotions.put("joy", ((result?.joy)?.times(100))?.toInt()!!)
+                                    emotions.put(
+                                        "regret",
+                                        ((result?.regret)?.times(100))?.toInt()!!
+                                    )
+                                    emotions.put(
+                                        "sadness",
+                                        ((result?.sadness)?.times(100))?.toInt()!!
+                                    )
+                                    emotions.put(
+                                        "tiredness",
+                                        ((result?.tiredness)?.times(100))?.toInt()!!
+                                    )
+                                    dDepression = (result?.depression)?.times(100)?.toInt()!!
+                                    Log.d("result", result.toString())
+                                } else {
+                                    // 통신 실패
+                                    Log.d("YMC", "onResponse 실패")
+                                }
+                            }
 
-						if (p1==0){
-							DiaryList(this).addDiary(CalendarDay(year, month, dayOfMonth), "neutrality")
-							Log.d("감정", "중립")
-						}
+                            override fun onFailure(call: Call<Classification>, t: Throwable) {
+                                // 통신 실패 (인터넷 끊킴, 예외 발생 등 시스템적인 이유)
+                                Log.d("YMC", "onFailure 에러: " + t.message.toString());
+                            }
+                        })
+                }
 
-						else
-							DiaryList(this).addDiary(CalendarDay(year, month, dayOfMonth), e1)
 
-						val intent = Intent(this, DiaryActivity::class.java)
-						intent.putExtra("year", year)
-						intent.putExtra("month", month)
-						intent.putExtra("dayOfMonth", dayOfMonth)
-						startActivity(intent)
-						finish()
-					}catch (e: ClassCastException){
-						Log.d("[error]", "ClassCastException")
+                Handler(Looper.getMainLooper()).postDelayed({
+                    try {
+                        Log.d("emotions", emotions.toString())
+                        val emotions2 = emotions.toList().sortedByDescending { (_, value) -> value }
+                            .toMap() as HashMap<String, Int>
+                        val e1 = emotions2.keys.elementAt(0)
+                        val p1 = emotions2.getValue(e1)
+                        var happiness = emotions.get("joy")?.plus(emotions.get("hope")!!)
+                        var depression = emotions.get("anger")?.plus(emotions.get("sadness")!!)
+                            ?.plus(emotions.get("anxiety")!!)?.plus(emotions.get("tiredness")!!)
+                            ?.plus(emotions.get("regret")!!)?.plus(dDepression)
+                        var representative = setRepresentative(e1, p1)
+                        CoroutineScope(Dispatchers.IO).launch {
+                            database?.ReportDao()?.insert(
+                                Report(
+                                    rDate,
+                                    content,
+                                    representative,
+                                    emotions,
+                                    happiness!!,
+                                    depression!!,
+                                    ""
+                                )
+                            )
+                        }
 
-						emotions.put("anger", 0)
-						emotions.put("anxiety", 0)
-						emotions.put("hope", 0)
-						emotions.put("joy", 0)
-						emotions.put("regret", 0)
-						emotions.put("sadness", 0)
-						emotions.put("tiredness", 0)
+                        if (p1 == 0) {
+                            DiaryList(this).addDiary(
+                                CalendarDay(year, month, dayOfMonth),
+                                "neutrality"
+                            )
+                            Log.d("감정", "중립")
+                        } else
+                            DiaryList(this).addDiary(CalendarDay(year, month, dayOfMonth), e1)
 
-						var happiness = emotions.get("joy")?.plus(emotions.get("hope")!!)
-						var depression = emotions.get("anger")?.plus(emotions.get("sadness")!!)?.plus(emotions.get("anxiety")!!)?.plus(emotions.get("tiredness")!!)?.plus(emotions.get("regret")!!)?.plus(dDepression)
-						var representative = "neutrality"
-						CoroutineScope(Dispatchers.IO).launch {
-							database?.ReportDao()?.insert(
-								Report(rDate, content, representative, emotions, happiness!!, depression!!, "")
-							)
-						}
-						DiaryList(this).addDiary(CalendarDay(year, month, dayOfMonth), "error")
-						val intent = Intent(this, DiaryActivity::class.java)
-						intent.putExtra("year", year)
-						intent.putExtra("month", month)
-						intent.putExtra("dayOfMonth", dayOfMonth)
-						intent.putExtra("data", 0)
-						startActivity(intent)
-						finish()
-					}
-				}, 10000)
-			}
-		}
+                        val intent = Intent(this, DiaryActivity::class.java)
+                        intent.putExtra("year", year)
+                        intent.putExtra("month", month)
+                        intent.putExtra("dayOfMonth", dayOfMonth)
+                        startActivity(intent)
+                        finish()
+                    } catch (e: ClassCastException) {
+                        Log.d("[error]", "ClassCastException")
+
+                        emotions.put("anger", 0)
+                        emotions.put("anxiety", 0)
+                        emotions.put("hope", 0)
+                        emotions.put("joy", 0)
+                        emotions.put("regret", 0)
+                        emotions.put("sadness", 0)
+                        emotions.put("tiredness", 0)
+
+                        var happiness = emotions.get("joy")?.plus(emotions.get("hope")!!)
+                        var depression = emotions.get("anger")?.plus(emotions.get("sadness")!!)
+                            ?.plus(emotions.get("anxiety")!!)?.plus(emotions.get("tiredness")!!)
+                            ?.plus(emotions.get("regret")!!)?.plus(dDepression)
+                        var representative = "neutrality"
+                        CoroutineScope(Dispatchers.IO).launch {
+                            database?.ReportDao()?.insert(
+                                Report(
+                                    rDate,
+                                    content,
+                                    representative,
+                                    emotions,
+                                    happiness!!,
+                                    depression!!,
+                                    ""
+                                )
+                            )
+                        }
+                        DiaryList(this).addDiary(CalendarDay(year, month, dayOfMonth), "error")
+                        val intent = Intent(this, DiaryActivity::class.java)
+                        intent.putExtra("year", year)
+                        intent.putExtra("month", month)
+                        intent.putExtra("dayOfMonth", dayOfMonth)
+                        intent.putExtra("data", 0)
+                        startActivity(intent)
+                        finish()
+                    }
+                }, 10000)
+            }
+        }
 
         binding.btnMusic.setOnLongClickListener {
             setFragment(MusicPopupFragment())
@@ -414,13 +453,13 @@ class WriteActivity : AppCompatActivity() {
         }
     }
 
-	private fun setLoadingFrag() {
-		val transaction = supportFragmentManager.beginTransaction()
-		transaction
-			.replace(R.id.wholeView, LoadingFragment())
-			.addToBackStack(null)
-			.commit()
-	}
+    private fun setLoadingFrag() {
+        val transaction = supportFragmentManager.beginTransaction()
+        transaction
+            .replace(R.id.wholeView, LoadingFragment())
+            .addToBackStack(null)
+            .commit()
+    }
 
     override fun onResume() {
         super.onResume()


### PR DESCRIPTION
# 수정 내용
1. WriteActivity에서 editText 부분을 누르면 음악 수정 팝업이 제대로 꺼지도록 수정함
2. save 버튼을 눌러서 10초가량의 **로딩화면으로 넘어갈 때, 듣고 있던 감정음악은 꺼지고 시그니처 음악이 켜지도록** 함 (설정에서 시그니처 음악 재생을 On 한 경우에만)

# 추가 개발 내용
1. 일기 쓰면서 엔터키 누를 때마다 감정에 맞는 음악이 나오도록 함

# 생각해볼 내용
지금 틀어지고 있는 음악과, 선택팝업에서 기본값으로 보여지는 음악은 관계 없음.
선택팝업은 오로지 넘버피커를 넘길 때, **그 순간의 변화만 측정**함. 지금 재생되는 음악이 어떤 감정인지, 내가 직전에 피커로 선택한 음악이 어떤 감정인지 알 수 없음.

이걸 알 수 있다면 좋겠지만.. 
난 그냥 이대로도 괜찮을 것 같다고 생각하는데 여러분은 어떠십니까?