### PR TITLE
fix: add email check logic, delete toast msg

### DIFF
--- a/app/src/main/java/com/nicer/attiary/view/auth/sign_up/SignUpActivity.kt
+++ b/app/src/main/java/com/nicer/attiary/view/auth/sign_up/SignUpActivity.kt
@@ -80,15 +80,14 @@ class SignUpActivity : AppCompatActivity() {
 		binding.buttonSubmit.setOnClickListener {
 			val email = binding.editEmail.text.toString()
 			val name = binding.editName.text.toString()
-			if(name == null){
+			if(name == "" || email == ""){
 				val builder = AlertDialog.Builder(this)
 				builder.setMessage("내용을 입력하세요.")
 				builder.setPositiveButton("확인", null)
 				builder.show()
 			}else{
-				val user = saveUser(email, name)
+				saveUser(email, name)
 				GlobalApplication.settingPrefs.setString("nickname", name)
-				Toast.makeText(this, "$user 저장됨!", Toast.LENGTH_SHORT).show()
 				startActivity(Intent(this, HomeActivity::class.java))
 				finish()
 			}


### PR DESCRIPTION
- email의 내용이 비어있을 때도 입력하도록 유도
- 정보등록을 성공했을 때 `user.toString()`을 호출해 어떤 정보로 저장되었는지 toast 메세지로 보여주던 기능 삭제